### PR TITLE
Larsp add context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ features = ["std", "serde", "kv_std", "kv_sval", "kv_serde"]
 
 [features]
 max_level_off   = []
+max_level_fatal = []
 max_level_error = []
 max_level_warn  = []
 max_level_info  = []
@@ -28,6 +29,7 @@ max_level_debug = []
 max_level_trace = []
 
 release_max_level_off   = []
+release_max_level_fatal = []
 release_max_level_error = []
 release_max_level_warn  = []
 release_max_level_info  = []
@@ -47,6 +49,8 @@ kv_unstable = ["kv", "value-bag"]
 kv_unstable_sval = ["kv_sval", "kv_unstable"]
 kv_unstable_std = ["kv_std", "kv_unstable"]
 kv_unstable_serde = ["kv_serde", "kv_unstable_std"]
+
+fatal = []
 
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ kv_unstable_std = ["kv_std", "kv_unstable"]
 kv_unstable_serde = ["kv_serde", "kv_unstable_std"]
 
 fatal = []
+context = []
 
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false }

--- a/src/__private_api.rs
+++ b/src/__private_api.rs
@@ -59,6 +59,7 @@ fn log_impl<L: Log>(
     level: Level,
     &(target, module_path, loc): &(&str, &'static str, &'static Location),
     kvs: Option<&[(&str, Value)]>,
+    #[cfg(feature = "context")] context_id: Option<&'static str>,
 ) {
     #[cfg(not(feature = "kv"))]
     if kvs.is_some() {
@@ -77,6 +78,11 @@ fn log_impl<L: Log>(
 
     #[cfg(feature = "kv")]
     builder.key_values(&kvs);
+
+    #[cfg(feature = "context")]
+    if let Some(context_id) = context_id {
+        builder.context_id(Some(context_id));
+    }
 
     logger.log(&builder.build());
 }
@@ -97,6 +103,30 @@ pub fn log<'a, K, L>(
         level,
         target_module_path_and_loc,
         kvs.into_kvs(),
+        #[cfg(feature = "context")]
+        None,
+    )
+}
+
+#[cfg(feature = "context")]
+pub fn log_with_context<'a, K, L>(
+    logger: L,
+    args: Arguments,
+    level: Level,
+    target_module_path_and_loc: &(&str, &'static str, &'static Location),
+    kvs: K,
+    context_id: &'static str,
+) where
+    K: KVs<'a>,
+    L: Log,
+{
+    log_impl(
+        logger,
+        args,
+        level,
+        target_module_path_and_loc,
+        kvs.into_kvs(),
+        Some(context_id),
     )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,12 +350,27 @@
 #![deny(missing_debug_implementations, unconditional_recursion)]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 
+#[cfg(all(
+    not(feature = "fatal"),
+    any(feature = "max_level_fatal", feature = "release_max_level_fatal")
+))]
+compile_error!(
+    "A fatal log level is enabled, but the `fatal` feature is not set. \
+                 Enable the `fatal` feature to use the fatal log level."
+);
+
 #[cfg(any(
+    all(feature = "max_level_off", feature = "max_level_fatal"),
     all(feature = "max_level_off", feature = "max_level_error"),
     all(feature = "max_level_off", feature = "max_level_warn"),
     all(feature = "max_level_off", feature = "max_level_info"),
     all(feature = "max_level_off", feature = "max_level_debug"),
     all(feature = "max_level_off", feature = "max_level_trace"),
+    all(feature = "max_level_fatal", feature = "max_level_error"),
+    all(feature = "max_level_fatal", feature = "max_level_warn"),
+    all(feature = "max_level_fatal", feature = "max_level_info"),
+    all(feature = "max_level_fatal", feature = "max_level_debug"),
+    all(feature = "max_level_fatal", feature = "max_level_trace"),
     all(feature = "max_level_error", feature = "max_level_warn"),
     all(feature = "max_level_error", feature = "max_level_info"),
     all(feature = "max_level_error", feature = "max_level_debug"),
@@ -371,11 +386,17 @@ compile_error!("multiple max_level_* features set");
 
 #[rustfmt::skip]
 #[cfg(any(
+    all(feature = "release_max_level_off", feature = "release_max_level_fatal"),
     all(feature = "release_max_level_off", feature = "release_max_level_error"),
     all(feature = "release_max_level_off", feature = "release_max_level_warn"),
     all(feature = "release_max_level_off", feature = "release_max_level_info"),
     all(feature = "release_max_level_off", feature = "release_max_level_debug"),
     all(feature = "release_max_level_off", feature = "release_max_level_trace"),
+    all(feature = "release_max_level_fatal", feature = "release_max_level_error"),
+    all(feature = "release_max_level_fatal", feature = "release_max_level_warn"),
+    all(feature = "release_max_level_fatal", feature = "release_max_level_info"),
+    all(feature = "release_max_level_fatal", feature = "release_max_level_debug"),
+    all(feature = "release_max_level_fatal", feature = "release_max_level_trace"),
     all(feature = "release_max_level_error", feature = "release_max_level_warn"),
     all(feature = "release_max_level_error", feature = "release_max_level_info"),
     all(feature = "release_max_level_error", feature = "release_max_level_debug"),
@@ -468,6 +489,10 @@ const INITIALIZED: usize = 2;
 
 static MAX_LOG_LEVEL_FILTER: AtomicUsize = AtomicUsize::new(0);
 
+#[cfg(feature = "fatal")]
+static LOG_LEVEL_NAMES: [&str; 7] = ["OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
+
+#[cfg(not(feature = "fatal"))]
 static LOG_LEVEL_NAMES: [&str; 6] = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
 
 static SET_LOGGER_ERROR: &str = "attempted to set a logger after the logging system \
@@ -484,13 +509,18 @@ static LEVEL_PARSE_ERROR: &str =
 #[repr(usize)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub enum Level {
+    #[cfg(feature = "fatal")]
+    /// The "fatal" level.
+    ///
+    /// Designates fatal errors that cause the program to abort.
+    Fatal = 1,
     /// The "error" level.
     ///
     /// Designates very serious errors.
     // This way these line up with the discriminants for LevelFilter below
     // This works because Rust treats field-less enums the same way as C does:
     // https://doc.rust-lang.org/reference/items/enumerations.html#custom-discriminant-values-for-field-less-enumerations
-    Error = 1,
+    Error = if cfg!(feature = "fatal") { 2 } else { 1 },
     /// The "warn" level.
     ///
     /// Designates hazardous situations.
@@ -544,6 +574,20 @@ impl fmt::Display for Level {
 }
 
 impl Level {
+    #[cfg(feature = "fatal")]
+    fn from_usize(u: usize) -> Option<Level> {
+        match u {
+            1 => Some(Level::Fatal),
+            2 => Some(Level::Error),
+            3 => Some(Level::Warn),
+            4 => Some(Level::Info),
+            5 => Some(Level::Debug),
+            6 => Some(Level::Trace),
+            _ => None,
+        }
+    }
+
+    #[cfg(not(feature = "fatal"))]
     fn from_usize(u: usize) -> Option<Level> {
         match u {
             1 => Some(Level::Error),
@@ -577,10 +621,13 @@ impl Level {
     /// Iterate through all supported logging levels.
     ///
     /// The order of iteration is from more severe to less severe log messages.
+    /// In case you use the `fatal` cargo feature, Level::Fatal will be the first item in
+    /// the iterator, otherwise Level::Error will be the first item. The following example
+    /// is for the case when the `fatal` feature is not enabled, which is the default.
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// use log::Level;
     ///
     /// let mut levels = Level::iter();
@@ -589,7 +636,7 @@ impl Level {
     /// assert_eq!(Some(Level::Trace), levels.last());
     /// ```
     pub fn iter() -> impl Iterator<Item = Self> {
-        (1..6).map(|i| Self::from_usize(i).unwrap())
+        (1..LOG_LEVEL_NAMES.len()).map(|i| Self::from_usize(i).unwrap())
     }
 }
 
@@ -606,6 +653,9 @@ impl Level {
 pub enum LevelFilter {
     /// A level lower than all log levels.
     Off,
+    /// Corresponds to the `Fatal` log level.
+    #[cfg(feature = "fatal")]
+    Fatal,
     /// Corresponds to the `Error` log level.
     Error,
     /// Corresponds to the `Warn` log level.
@@ -650,6 +700,21 @@ impl fmt::Display for LevelFilter {
 }
 
 impl LevelFilter {
+    #[cfg(feature = "fatal")]
+    fn from_usize(u: usize) -> Option<LevelFilter> {
+        match u {
+            0 => Some(LevelFilter::Off),
+            1 => Some(LevelFilter::Fatal),
+            2 => Some(LevelFilter::Error),
+            3 => Some(LevelFilter::Warn),
+            4 => Some(LevelFilter::Info),
+            5 => Some(LevelFilter::Debug),
+            6 => Some(LevelFilter::Trace),
+            _ => None,
+        }
+    }
+
+    #[cfg(not(feature = "fatal"))]
     fn from_usize(u: usize) -> Option<LevelFilter> {
         match u {
             0 => Some(LevelFilter::Off),
@@ -698,7 +763,7 @@ impl LevelFilter {
     /// assert_eq!(Some(LevelFilter::Trace), levels.last());
     /// ```
     pub fn iter() -> impl Iterator<Item = Self> {
-        (0..6).map(|i| Self::from_usize(i).unwrap())
+        (0..LOG_LEVEL_NAMES.len()).map(|i| Self::from_usize(i).unwrap())
     }
 }
 
@@ -1306,11 +1371,13 @@ pub unsafe fn set_max_level_racy(level: LevelFilter) {
 
 /// Returns the current maximum log level.
 ///
-/// The [`log!`], [`error!`], [`warn!`], [`info!`], [`debug!`], and [`trace!`] macros check
-/// this value and discard any message logged at a higher level. The maximum
+/// The [`log!`], [`fatal!`], [`error!`], [`warn!`], [`info!`], [`debug!`], and [`trace!`]
+/// macros checkthis value and discard any message logged at a higher level. The maximum
 /// log level is set by the [`set_max_level`] function.
+/// The fatal level is only available when the `fatal` cargo feature is enabled.
 ///
 /// [`log!`]: macro.log.html
+/// [`fatal!`]: macro.error.html
 /// [`error!`]: macro.error.html
 /// [`warn!`]: macro.warn.html
 /// [`info!`]: macro.info.html
@@ -1535,12 +1602,16 @@ pub mod __private_api;
 /// [`logger`]: fn.logger.html
 pub const STATIC_MAX_LEVEL: LevelFilter = match cfg!(debug_assertions) {
     false if cfg!(feature = "release_max_level_off") => LevelFilter::Off,
+    #[cfg(feature = "fatal")]
+    false if cfg!(feature = "release_max_level_fatal") => LevelFilter::Fatal,
     false if cfg!(feature = "release_max_level_error") => LevelFilter::Error,
     false if cfg!(feature = "release_max_level_warn") => LevelFilter::Warn,
     false if cfg!(feature = "release_max_level_info") => LevelFilter::Info,
     false if cfg!(feature = "release_max_level_debug") => LevelFilter::Debug,
     false if cfg!(feature = "release_max_level_trace") => LevelFilter::Trace,
     _ if cfg!(feature = "max_level_off") => LevelFilter::Off,
+    #[cfg(feature = "fatal")]
+    _ if cfg!(feature = "max_level_fatal") => LevelFilter::Fatal,
     _ if cfg!(feature = "max_level_error") => LevelFilter::Error,
     _ if cfg!(feature = "max_level_warn") => LevelFilter::Warn,
     _ if cfg!(feature = "max_level_info") => LevelFilter::Info,
@@ -1556,12 +1627,16 @@ mod tests {
     fn test_levelfilter_from_str() {
         let tests = [
             ("off", Ok(LevelFilter::Off)),
+            #[cfg(feature = "fatal")]
+            ("fatal", Ok(LevelFilter::Fatal)),
             ("error", Ok(LevelFilter::Error)),
             ("warn", Ok(LevelFilter::Warn)),
             ("info", Ok(LevelFilter::Info)),
             ("debug", Ok(LevelFilter::Debug)),
             ("trace", Ok(LevelFilter::Trace)),
             ("OFF", Ok(LevelFilter::Off)),
+            #[cfg(feature = "fatal")]
+            ("FATAL", Ok(LevelFilter::Fatal)),
             ("ERROR", Ok(LevelFilter::Error)),
             ("WARN", Ok(LevelFilter::Warn)),
             ("INFO", Ok(LevelFilter::Info)),
@@ -1578,11 +1653,15 @@ mod tests {
     fn test_level_from_str() {
         let tests = [
             ("OFF", Err(ParseLevelError(()))),
+            #[cfg(feature = "fatal")]
+            ("fatal", Ok(Level::Fatal)),
             ("error", Ok(Level::Error)),
             ("warn", Ok(Level::Warn)),
             ("info", Ok(Level::Info)),
             ("debug", Ok(Level::Debug)),
             ("trace", Ok(Level::Trace)),
+            #[cfg(feature = "fatal")]
+            ("FATAL", Ok(Level::Fatal)),
             ("ERROR", Ok(Level::Error)),
             ("WARN", Ok(Level::Warn)),
             ("INFO", Ok(Level::Info)),
@@ -1598,6 +1677,8 @@ mod tests {
     #[test]
     fn test_level_as_str() {
         let tests = &[
+            #[cfg(feature = "fatal")]
+            (Level::Fatal, "FATAL"),
             (Level::Error, "ERROR"),
             (Level::Warn, "WARN"),
             (Level::Info, "INFO"),
@@ -1652,6 +1733,8 @@ mod tests {
     fn test_level_filter_as_str() {
         let tests = &[
             (LevelFilter::Off, "OFF"),
+            #[cfg(feature = "fatal")]
+            (LevelFilter::Fatal, "FATAL"),
             (LevelFilter::Error, "ERROR"),
             (LevelFilter::Warn, "WARN"),
             (LevelFilter::Info, "INFO"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,7 +520,10 @@ pub enum Level {
     // This way these line up with the discriminants for LevelFilter below
     // This works because Rust treats field-less enums the same way as C does:
     // https://doc.rust-lang.org/reference/items/enumerations.html#custom-discriminant-values-for-field-less-enumerations
-    Error = if cfg!(feature = "fatal") { 2 } else { 1 },
+    #[cfg(feature = "fatal")]
+    Error = 2,
+    #[cfg(not(feature = "fatal"))]
+    Error = 1,
     /// The "warn" level.
     ///
     /// Designates hazardous situations.
@@ -1162,6 +1165,7 @@ impl Default for RecordBuilder<'_> {
 ///
 /// # fn main(){}
 /// ```
+
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Metadata<'a> {
     level: Level,
@@ -1390,7 +1394,7 @@ pub unsafe fn set_max_level_racy(level: LevelFilter) {
 /// Returns the current maximum log level.
 ///
 /// The [`log!`], [`fatal!`], [`error!`], [`warn!`], [`info!`], [`debug!`], and [`trace!`]
-/// macros checkthis value and discard any message logged at a higher level. The maximum
+/// macros check this value and discard any message logged at a higher level. The maximum
 /// log level is set by the [`set_max_level`] function.
 /// The fatal level is only available when the `fatal` cargo feature is enabled.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -837,6 +837,8 @@ pub struct Record<'a> {
     line: Option<u32>,
     #[cfg(feature = "kv")]
     key_values: KeyValues<'a>,
+    #[cfg(feature = "context")]
+    context_id: Option<&'a str>,
 }
 
 // This wrapper type is only needed so we can
@@ -948,6 +950,12 @@ impl<'a> Record<'a> {
             },
         }
     }
+
+    #[cfg(feature = "context")]
+    /// The context id associated with the message.
+    pub fn context_id(&self) -> Option<&str> {
+        self.context_id
+    }
 }
 
 /// Builder for [`Record`](struct.Record.html).
@@ -1018,6 +1026,8 @@ impl<'a> RecordBuilder<'a> {
                 line: None,
                 #[cfg(feature = "kv")]
                 key_values: KeyValues(&None::<(kv::Key, kv::Value)>),
+                #[cfg(feature = "context")]
+                context_id: None,
             },
         }
     }
@@ -1090,6 +1100,14 @@ impl<'a> RecordBuilder<'a> {
     #[inline]
     pub fn key_values(&mut self, kvs: &'a dyn kv::Source) -> &mut RecordBuilder<'a> {
         self.record.key_values = KeyValues(kvs);
+        self
+    }
+
+    /// Set the [`context id`](struct.Record.html#method.context_id) associated with the message.
+    #[cfg(feature = "context")]
+    #[inline]
+    pub fn context_id(&mut self, context_id: Option<&'a str>) -> &mut RecordBuilder<'a> {
+        self.record.context_id = context_id;
         self
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -73,6 +73,50 @@
 #[macro_export]
 #[clippy::format_args]
 macro_rules! log {
+    // log!(logger: my_logger, target: "my_target", context: "ctx42", Level::Info, "a {} event", "log");
+    (logger: $logger:expr, target: $target:expr, context: $context_id:expr, $lvl:expr, $($arg:tt)+) => ({
+        $crate::__log!(
+            logger: $crate::__log_logger!($logger),
+            target: $target,
+            context: $context_id,
+            $lvl,
+            $($arg)+
+        )
+    });
+
+    // log!(logger: my_logger, context: "ctx42", Level::Info, "a log event")
+    (logger: $logger:expr, context: $context_id:expr, $lvl:expr, $($arg:tt)+) => ({
+        $crate::__log!(
+            logger: $crate::__log_logger!($logger),
+            target: $crate::__private_api::module_path!(),
+            context: $context_id,
+            $lvl,
+            $($arg)+
+        )
+    });
+
+    // log!(target: "my_target", context: "ctx42", Level::Info, "a log event")
+    (target: $target:expr, context: $context_id:expr, $lvl:expr, $($arg:tt)+) => ({
+        $crate::__log!(
+            logger: $crate::__log_logger!(__log_global_logger),
+            target: $target,
+            context: $context_id,
+            $lvl,
+            $($arg)+
+        )
+    });
+
+    // log!(context: "ctx42", Level::Info, "a log event")
+    (context: $context_id:expr, $lvl:expr, $($arg:tt)+) => ({
+        $crate::__log!(
+            logger: $crate::__log_logger!(__log_global_logger),
+            target: $crate::__private_api::module_path!(),
+            context: $context_id,
+            $lvl,
+            $($arg)+
+        )
+    });
+
     // log!(logger: my_logger, target: "my_target", Level::Info, "a {} event", "log");
     (logger: $logger:expr, target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
         $crate::__log!(
@@ -117,6 +161,36 @@ macro_rules! log {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __log {
+    // __log!(logger: my_logger, target: "my_target", context: "ctx42", Level::Info, key1:? = 42, key2 = true; "a {} event", "log");
+    (logger: $logger:expr, target: $target:expr, context: $context_id:expr, $lvl:expr, $($key:tt $(:$capture:tt)? $(= $value:expr)?),+; $($arg:tt)+) => ({
+        let lvl = $lvl;
+        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
+            $crate::__private_api::log_with_context(
+                $logger,
+                $crate::__private_api::format_args!($($arg)+),
+                lvl,
+                &($target, $crate::__private_api::module_path!(), $crate::__private_api::loc()),
+                &[$(($crate::__log_key!($key), $crate::__log_value!($key $(:$capture)* = $($value)*))),+] as &[_],
+                $context_id,
+            );
+        }
+    });
+
+    // __log!(logger: my_logger, target: "my_target", context: "ctx42", Level::Info, "a {} event", "log");
+    (logger: $logger:expr, target: $target:expr, context: $context_id:expr, $lvl:expr, $($arg:tt)+) => ({
+        let lvl = $lvl;
+        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
+            $crate::__private_api::log_with_context(
+                $logger,
+                $crate::__private_api::format_args!($($arg)+),
+                lvl,
+                &($target, $crate::__private_api::module_path!(), $crate::__private_api::loc()),
+                (),
+                $context_id,
+            );
+        }
+    });
+
     // log!(logger: my_logger, target: "my_target", Level::Info, key1:? = 42, key2 = true; "a {} event", "log");
     (logger: $logger:expr, target: $target:expr, $lvl:expr, $($key:tt $(:$capture:tt)? $(= $value:expr)?),+; $($arg:tt)+) => ({
         let lvl = $lvl;
@@ -176,6 +250,26 @@ macro_rules! fatal {
         $crate::log!(logger: $crate::__log_logger!($logger), $crate::Level::Fatal, $($arg)+)
     });
 
+    // fatal!(logger: my_logger, target: "my_target", context: "ctx42", "a {} event", "log")
+    (logger: $logger:expr, target: $target:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(logger: $crate::__log_logger!($logger), target: $target, context: $context_id, $crate::Level::Fatal, $($arg)+)
+    });
+
+    // fatal!(logger: my_logger, context: "ctx42", "a {} event", "log")
+    (logger: $logger:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(logger: $crate::__log_logger!($logger), context: $context_id, $crate::Level::Fatal, $($arg)+)
+    });
+
+    // fatal!(target: "my_target", context: "ctx42", "a {} event", "log")
+    (target: $target:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(target: $target, context: $context_id, $crate::Level::Fatal, $($arg)+)
+    });
+
+    // fatal!(context: "ctx42", "a {} event", "log")
+    (context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(context: $context_id, $crate::Level::Error, $($arg)+)
+    });
+
     // fatal!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
     // fatal!(target: "my_target", "a {} event", "log")
     (target: $target:expr, $($arg:tt)+) => ({
@@ -215,6 +309,26 @@ macro_rules! error {
         $crate::log!(logger: $crate::__log_logger!($logger), $crate::Level::Error, $($arg)+)
     });
 
+    // error!(logger: my_logger, target: "my_target", context: "ctx42", "a {} event", "log")
+    (logger: $logger:expr, target: $target:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(logger: $crate::__log_logger!($logger), target: $target, context: $context_id, $crate::Level::Error, $($arg)+)
+    });
+
+    // error!(logger: my_logger, context: "ctx42", "a {} event", "log")
+    (logger: $logger:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(logger: $crate::__log_logger!($logger), context: $context_id, $crate::Level::Error, $($arg)+)
+    });
+
+    // error!(target: "my_target", context: "ctx42", "a {} event", "log")
+    (target: $target:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(target: $target, context: $context_id, $crate::Level::Error, $($arg)+)
+    });
+
+    // error!(context: "ctx42", "a {} event", "log")
+    (context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(context: $context_id, $crate::Level::Error, $($arg)+)
+    });
+
     // error!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
     // error!(target: "my_target", "a {} event", "log")
     (target: $target:expr, $($arg:tt)+) => ({
@@ -252,6 +366,26 @@ macro_rules! warn {
     // warn!(logger: my_logger, "a {} event", "log")
     (logger: $logger:expr, $($arg:tt)+) => ({
         $crate::log!(logger: $crate::__log_logger!($logger), $crate::Level::Warn, $($arg)+)
+    });
+
+    // warn!(logger: my_logger, target: "my_target", context: "ctx42", "a {} event", "log")
+    (logger: $logger:expr, target: $target:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(logger: $crate::__log_logger!($logger), target: $target, context: $context_id, $crate::Level::Warn, $($arg)+)
+    });
+
+    // warn!(logger: my_logger, context: "ctx42", "a {} event", "log")
+    (logger: $logger:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(logger: $crate::__log_logger!($logger), context: $context_id, $crate::Level::Warn, $($arg)+)
+    });
+
+    // warn!(target: "my_target", context: "ctx42", "a {} event", "log")
+    (target: $target:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(target: $target, context: $context_id, $crate::Level::Warn, $($arg)+)
+    });
+
+    // warn!(context: "ctx42", "a {} event", "log")
+    (context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(context: $context_id, $crate::Level::Warn, $($arg)+)
     });
 
     // warn!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
@@ -302,6 +436,26 @@ macro_rules! info {
         $crate::log!(logger: $crate::__log_logger!($logger), $crate::Level::Info, $($arg)+)
     });
 
+    // info!(logger: my_logger, target: "my_target", context: "ctx42", "a {} event", "log")
+    (logger: $logger:expr, target: $target:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(logger: $crate::__log_logger!($logger), target: $target, context: $context_id, $crate::Level::Info, $($arg)+)
+    });
+
+    // info!(logger: my_logger, context: "ctx42", "a {} event", "log")
+    (logger: $logger:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(logger: $crate::__log_logger!($logger), context: $context_id, $crate::Level::Info, $($arg)+)
+    });
+
+    // info!(target: "my_target", context: "ctx42", "a {} event", "log")
+    (target: $target:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(target: $target, context: $context_id, $crate::Level::Info, $($arg)+)
+    });
+
+    // info!(context: "ctx42", "a {} event", "log")
+    (context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(context: $context_id, $crate::Level::Info, $($arg)+)
+    });
+
     // info!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
     // info!(target: "my_target", "a {} event", "log")
     (target: $target:expr, $($arg:tt)+) => ({
@@ -340,6 +494,26 @@ macro_rules! debug {
     // debug!(logger: my_logger, "a {} event", "log")
     (logger: $logger:expr, $($arg:tt)+) => ({
         $crate::log!(logger: $crate::__log_logger!($logger), $crate::Level::Debug, $($arg)+)
+    });
+
+    // debug!(logger: my_logger, target: "my_target", context: "ctx42", "a {} event", "log")
+    (logger: $logger:expr, target: $target:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(logger: $crate::__log_logger!($logger), target: $target, context: $context_id, $crate::Level::Debug, $($arg)+)
+    });
+
+    // debug!(logger: my_logger, context: "ctx42", "a {} event", "log")
+    (logger: $logger:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(logger: $crate::__log_logger!($logger), context: $context_id, $crate::Level::Debug, $($arg)+)
+    });
+
+    // debug!(target: "my_target", context: "ctx42", "a {} event", "log")
+    (target: $target:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(target: $target, context: $context_id, $crate::Level::Debug, $($arg)+)
+    });
+
+    // debug!(context: "ctx42", "a {} event", "log")
+    (context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(context: $context_id, $crate::Level::Debug, $($arg)+)
     });
 
     // debug!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
@@ -384,6 +558,26 @@ macro_rules! trace {
     // trace!(logger: my_logger, "a {} event", "log")
     (logger: $logger:expr, $($arg:tt)+) => ({
         $crate::log!(logger: $crate::__log_logger!($logger), $crate::Level::Trace, $($arg)+)
+    });
+
+    // trace!(logger: my_logger, target: "my_target", context: "ctx42", "a {} event", "log")
+    (logger: $logger:expr, target: $target:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(logger: $crate::__log_logger!($logger), target: $target, context: $context_id, $crate::Level::Trace, $($arg)+)
+    });
+
+    // trace!(logger: my_logger, context: "ctx42", "a {} event", "log")
+    (logger: $logger:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(logger: $crate::__log_logger!($logger), context: $context_id, $crate::Level::Trace, $($arg)+)
+    });
+
+    // trace!(target: "my_target", context: "ctx42", "a {} event", "log")
+    (target: $target:expr, context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(target: $target, context: $context_id, $crate::Level::Trace, $($arg)+)
+    });
+
+    // trace!(context: "ctx42", "a {} event", "log")
+    (context: $context_id:expr, $($arg:tt)+) => ({
+        $crate::log!(context: $context_id, $crate::Level::Trace, $($arg)+)
     });
 
     // trace!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -267,7 +267,7 @@ macro_rules! fatal {
 
     // fatal!(context: "ctx42", "a {} event", "log")
     (context: $context_id:expr, $($arg:tt)+) => ({
-        $crate::log!(context: $context_id, $crate::Level::Error, $($arg)+)
+        $crate::log!(context: $context_id, $crate::Level::Fatal, $($arg)+)
     });
 
     // fatal!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -146,6 +146,46 @@ macro_rules! __log {
     });
 }
 
+/// Logs a message at the fatal level.
+///
+/// # Examples
+///
+/// ```
+/// use log::fatal;
+///
+/// # let my_logger = log::__private_api::GlobalLogger;
+/// let (err_info, port) = ("No connection", 22);
+///
+/// fatal!("Error: {err_info} on port {port}");
+/// fatal!(target: "app_events", "App Error: {err_info}, Port: {port}");
+/// fatal!(logger: my_logger, "App Error: {err_info}, Port: {port}");
+/// ```
+#[macro_export]
+#[clippy::format_args]
+#[cfg(feature = "fatal")]
+macro_rules! fatal {
+    // fatal!(logger: my_logger, target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
+    // fatal!(logger: my_logger, target: "my_target", "a {} event", "log")
+    (logger: $logger:expr, target: $target:expr, $($arg:tt)+) => ({
+        $crate::log!(logger: $crate::__log_logger!($logger), target: $target, $crate::Level::Fatal, $($arg)+)
+    });
+
+    // fatal!(logger: my_logger, key1 = 42, key2 = true; "a {} event", "log")
+    // fatal!(logger: my_logger, "a {} event", "log")
+    (logger: $logger:expr, $($arg:tt)+) => ({
+        $crate::log!(logger: $crate::__log_logger!($logger), $crate::Level::Fatal, $($arg)+)
+    });
+
+    // fatal!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
+    // fatal!(target: "my_target", "a {} event", "log")
+    (target: $target:expr, $($arg:tt)+) => ({
+        $crate::log!(target: $target, $crate::Level::Fatal, $($arg)+)
+    });
+
+    // fatal!("a {} event", "log")
+    ($($arg:tt)+) => ($crate::log!($crate::Level::Fatal, $($arg)+))
+}
+
 /// Logs a message at the error level.
 ///
 /// # Examples

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -7,6 +7,8 @@ macro_rules! all_log_macros {
         ::log::info!($($arg)*);
         ::log::warn!($($arg)*);
         ::log::error!($($arg)*);
+        #[cfg(feature = "fatal")]
+        ::log::fatal!($($arg)*);
     });
 }
 


### PR DESCRIPTION
This PR introduces a new fatal log level and adds optional context IDs to log records, updating macros, API structures, feature flags, and tests to support both.

    Added a fatal! macro and Level::Fatal variant (feature-gated under fatal).
    Extended log!, __log!, and level-specific macros to accept a context argument and updated the internal API (Record, builder, private API).
    Updated Cargo.toml, compile-time guards, and tests to cover the new fatal and context features.
